### PR TITLE
Quality Option Fix

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
       };
 
       // variable
-      var sizeOptions = _.clone(_.extend(s, DEFAULT_SIZE_OPTIONS));
+      var sizeOptions = _.clone(_.extend(DEFAULT_SIZE_OPTIONS, s));
       var sizingMethod = 'resize';
 
       if (!isValidSize(s)) {
@@ -126,7 +126,7 @@ module.exports = function(grunt) {
         imageOptions = {
           srcPath:  srcPath,
           dstPath:  dstPath,
-          format:   extName
+          format:   extName.replace('.', '')
         };
 
         // combine image options with size options.


### PR DESCRIPTION
Great plugin you have here! Thanks!

I noticed the same quality issues that were in #1.

These seem to fix the issue :tada: 

---
1. Quality settings were always overwritten with the defaults
   - _.extend expects the defaults passed in as the first argument
   - http://underscorejs.org/#extend
2. node-imagemagick only adds the quality option if the format is 'jpg' or 'jpeg'. Currently sending in '.jpg' or '.jpeg'
   - https://github.com/rsms/node-imagemagick/blob/master/imagemagick.js#L393
