### PR TITLE
make output less verbose in normal setting, include tally

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -67,20 +67,21 @@ module.exports = function(grunt) {
   }
 
   grunt.registerMultiTask('responsive_images', 'Images at various responsive sizes', function() {
-    
+
     // Merge task-specific and/or target-specific options with these defaults.
-    
+
     var done = this.async();
     var series = [];
     var options = this.options(DEFAULT_OPTIONS);
     var that = this;
+    var tally = {};
 
     if (!isValidArray(options.sizes)) {
       return grunt.fail.warn('No sizes have been defined.');
     }
 
     options.sizes.forEach(function(s) {
-      
+
       // consts
       var DEFAULT_SIZE_OPTIONS = {
         quality: 1
@@ -101,6 +102,8 @@ module.exports = function(grunt) {
 
       // create a name suffix for our image
       sizeOptions.name = getName(s.name, s.width, s.height, options.separator, s.suffix);
+
+      tally[sizeOptions.name] = 0;
 
       // Iterate over all specified file groups.
       that.files.forEach(function(f) {
@@ -137,15 +140,21 @@ module.exports = function(grunt) {
             if (error) {
               grunt.fail.warn(error.message);
             } else {
-              grunt.log.ok('Responsive Image: ' + srcPath + ' now '+ dstPath);
+              grunt.verbose.ok('Responsive Image: ' + srcPath + ' now '+ dstPath);
+              tally[sizeOptions.name]++;
             }
             return callback();
           });
-
         });
+      });
+      series.push(function(callback) {
+        if (tally[sizeOptions.name]) {
+          grunt.log.writeln('Created ' + tally[sizeOptions.name].toString().cyan + ' files for size ' + sizeOptions.name);
+        }
+        return callback();
       });
     });
 
     async.series(series, done);
-  });  
+  });
 };


### PR DESCRIPTION
Make the output less verbose by using `grunt.verbose` for the line by line output of each file created.

Include a tally for the total file created for each size declared.

The tally output isn't ideal as it uses `sizeOptions.name`, which includes the separator `-` in it. But it works for now.
