### PR TITLE
Move contrib packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
     "lodash": "~1.0.0",
     "node-imagemagick": "~0.1.8",
     "async": "~0.2.8",
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.2.0",
     "grunt": "~0.4.1"
   },
+  "devDependencies": {
+    "grunt-contrib-jshint": "~0.6.0",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-nodeunit": "~0.2.0"
+  }
   "keywords": [
     "gruntplugin"
   ]


### PR DESCRIPTION
This aren't actually required for the plug-in to work and shouldn't have to be downloaded if someone is installing this into their project.
