### PR TITLE
Allow strings as valid sizes, e.g. "50%"

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -39,7 +39,10 @@ module.exports = function(grunt) {
 
   // check whether we've been given any valid size values
   function isValidSize(obj) {
-    return (_.isNumber(obj.width) || _.isNumber(obj.height));
+    return _.isNumber(obj.width) ||
+      _.isNumber(obj.height) ||
+      _.isString(obj.width) ||
+      _.isString(obj.height);
   }
 
   // create a name to suffix to our file.


### PR DESCRIPTION
By allowing isValidSize() to also accept strings we can use ImageMagick's support for specifying dimensions by percentages. All tests passing.

Partially addresses Issue #5.

TODO: Possible changes to the file and directory auto-naming scheme and necessary tests.
