### PR TITLE
Fix imageMagick problem

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -81,7 +81,7 @@ module.exports = function(grunt) {
       return grunt.fail.warn('Invalid render engine specified');
     }
     grunt.verbose.ok('Using render engine: ' + GFX_ENGINES[engine].name);
-    gm.subClass({ imageMagick: (engine === 'im') });
+    gm = gm.subClass({ imageMagick: (engine === 'im') });
   };
 
   /**


### PR DESCRIPTION
Overwriting gm with return from subClass fixes the imageMagick not found errors, when imageMagick is actually installed.
