### PR TITLE
Add custom rename function

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -283,11 +283,13 @@ module.exports = function(grunt) {
    * @param   {object}          sizeOptions
    * @param   {string}          customDest 
    * @param   {string}          origCwd
+   * @param   {function}        customRenameFunc
    */
-  var getDestination = function(srcPath, dstPath, sizeOptions, customDest, origCwd) {
+  var getDestination = function(srcPath, dstPath, sizeOptions, customDest, origCwd, customRenameFunc) {
     var baseName = '',
         dirName = '',
-        extName = '';
+        extName = '',
+        dest;
 
     extName = path.extname(dstPath);
     baseName = path.basename(srcPath, extName); // filename without extension
@@ -303,8 +305,15 @@ module.exports = function(grunt) {
         data: sizeOptions
       });
 
-      checkDirectoryExists(path.join(dirName));
-      return path.join(dirName, baseName + extName);
+      if (customRenameFunc) {
+        dest = customRenameFunc(dirName, baseName + extName);
+        checkDirectoryExists(path.dirname(dest))
+      } else {
+        dest = path.join(dirName, baseName + extName);
+        checkDirectoryExists(path.join(dirName));
+      }
+
+      return dest;
 
     } else {
       
@@ -370,7 +379,7 @@ module.exports = function(grunt) {
           sizeOptions.outputName = addPrefixSuffix(sizeOptions.name, options.separator, sizeOptions.suffix);
 
           srcPath = f.src[0];
-          dstPath = getDestination(srcPath, f.dest, sizeOptions, f.custom_dest, f.orig.cwd);
+          dstPath = getDestination(srcPath, f.dest, sizeOptions, f.custom_dest, f.orig.cwd, f.orig.custom_rename);
 
           // remove pixels from the value so the gfx process doesn't complain
           sizeOptions = removeCharsFromObjectValue(sizeOptions, ['width', 'height'], 'px');


### PR DESCRIPTION
Currently Grunt's built in rename function requires a `dest` option to be specified to run and is not compatible with the `custom_dest`option provided by this plugin. As it is useful to be able to run replace functions I have added a `custom_replace` function which like Grunt's `replace` takes two arguments `dest` and `src` and is expected to return a single path.