### PR TITLE
Feature Request: Labels for images

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -428,7 +428,12 @@ module.exports = function(grunt) {
                 image
                   .resize(sizeOptions.width, sizeOptions.height, sizingMethod)
                   .quality(sizeOptions.quality);
-
+                
+                if(sizeOptions.label) {
+                  image
+                    .drawText(20,20, sizeOptions.label);
+                }
+                
                 if (mode === 'crop') {
                   image
                     .gravity(sizeOptions.gravity)


### PR DESCRIPTION
When developing a responsive website, it is really really useful to have a label on the image which displays for example its dimension. This way you can really make sure your responsive image system is working...