### PR TITLE
Use sample() instead of resize()

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -348,7 +348,7 @@ module.exports = function(grunt) {
         }
 
         image
-          .resize(sizeOptions.width, sizeOptions.height, sizingMethod)
+          .sample(sizeOptions.width, sizeOptions.height, sizingMethod)
           .quality(sizeOptions.quality);
 
         if (mode === 'crop') {


### PR DESCRIPTION
Solves https://github.com/andismith/grunt-responsive-images/issues/63

I'm still running tests, but so far the results seem supes promising.
