### PR TITLE
Add development/test files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+demo/
+test/
+.jshintrc
+.travis.yml


### PR DESCRIPTION
Hello!

first of all: thank you for your great work. It's exactly what we need for our project and it's working really well.
Though there is one thing I dislike: It's the fact that you're shipping the npm package with the demo and test folders. They are taking over 20 MB of disk space (~95% of the size of the npm package). Together with the fact that our application creates a lot of small projects with their own toolchain it's just a waste of disk space. Of course I can easily solve the problem for our application, but as far as I know it's common practice to not include test data in npm packages (e.g. http://stackoverflow.com/questions/8617753/exclude-test-code-in-npm-package ). So, I wanted to send you a pull request and you can think about it :smile:

Regards,
Benni
