### PR TITLE
Custom command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ sizes: [{
     *Default:* `x`<br />
     *Version:* 0.1.0 and above
 
+* **options.customIn**
+  *Type:* `String`<br />
+  *Default:* `null`<br />
+  *Version:* 0.1.6 and above
+
+Custom input arguments as specified at https://github.com/aheckmann/gm#custom-arguments
+
+* **options.customOut**
+  *Type:* `String`<br />
+  *Default:* `null`<br />
+  *Version:* 0.1.6 and above
+
+Custom output arguments as specified at https://github.com/aheckmann/gm#custom-arguments
+
 ### Usage Examples
 
 #### Default Options

--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -352,7 +352,7 @@ module.exports = function(grunt) {
           image.in(sizeOptions.customIn);
         }
         if (sizeOptions.customOut) {
-          image.in(sizeOptions.customOut);
+          image.out(sizeOptions.customOut);
         }
 
         if (sizeOptions.filter) {

--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -31,6 +31,8 @@ module.exports = function(grunt) {
     separator: '-',             // separator between name and filesize
     tryAnimated: false,         // DEFAULT CHANGED - whether to try to resize animated files
     upscale: false,             // whether to upscale the image
+    customIn: null,
+    customOut: null,
     sizes: [{
       name: 'small',
       width: 320
@@ -346,6 +348,12 @@ module.exports = function(grunt) {
           }
         }
 
+        if (sizeOptions.customIn) {
+          image.in(sizeOptions.customIn);
+        }
+        if (sizeOptions.customOut) {
+          image.in(sizeOptions.customOut);
+        }
 
         if (sizeOptions.filter) {
           image.filter(sizeOptions.filter);


### PR DESCRIPTION
Allows to pass custom commands via `.in` and `.out` methods. Fixes #74 