### PR TITLE
Allow for empty name property.

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -161,7 +161,7 @@ module.exports = function(grunt) {
       heightUnit = '';
 
     // name takes precedence
-    if (properties.name) {
+    if (typeof properties.name !== undefined) {
       return properties.name;
     } else {
       // figure out the units for width and height (they can be different)


### PR DESCRIPTION
use `if (typeof properties.name !== undefined) { ... }` instead of `if (properties.name) { ... }`, allowing for "empty" file names, meaning that you can provide a spec like:

```js
{
    name: '',
    width: 768,
    suffix: '@2x',
    quality: 85
}
```

Meaning that you now can create a 'myfile@2x.jpg' for instance.