### PR TITLE
Fix recursive function

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -502,7 +502,8 @@ module.exports = function(grunt) {
                 return processImage(srcPath, dstPath, sizeOptions, tally, callback);
               } else {
                 grunt.verbose.ok('File already exists: ' + dstPath);
-                return callback();
+                // defer the callback
+                setImmediate(callback);
               }
             } else {
               return processImage(srcPath, dstPath, sizeOptions, tally, callback);


### PR DESCRIPTION
When you have a few thousands files and you run the option task `newFilesOnly`, an error occurs `Maximum call stack size exceeded`. Fix this issue by scheduling the "immediate" execution of callback after I/O events callbacks and before `setTimeout `and `setInterval ` — More info on `setImmediate` function here: http://nodejs.org/api/timers.html#timers_setimmediate_callback_arg