### PR TITLE
Performance improvement to gm.identify by adding format

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -313,10 +313,21 @@ module.exports = function(grunt) {
   var processImage = function(srcPath, dstPath, sizeOptions, tally, callback) {
     var image = gfxEngine(srcPath);
 
-    image.identify(function(err, data) {
+    image.identify("%m:%T:%s\n", function(err, dataRaw) {
       if(err){
         handleImageErrors(err, sizeOptions.engine);
       }
+
+      var lastLineData = dataRaw.trim().split("\n").slice(-1)[0].split(":");
+      if (lastLineData.length !== 3) {
+        handleImageErrors(new Error("Could not parse identify output: " + dataRaw), sizeOptions.engine);
+      }
+
+      var data = {
+        format: lastLineData[0],
+        Delay: parseInt(lastLineData[1], 10),
+        Scene: parseInt(lastLineData[2], 10)
+      };
 
       if (!isAnimatedGif(data, dstPath, sizeOptions.tryAnimated)) {
       image.size(function(error, size) {


### PR DESCRIPTION
Hello there,

today we had a problem in one of our projects, because the grunt task was running way too long (about 7 minutes). We investigated the case and found out that most of the time it was running grunt-responsive-images and in specific `gm identify -verbose -ping image.jpg`. After reading a bit further I found out, that this is caused by node-gm, because no format option was given to image.identify() (which is highly recommended according to their docs). So, I added a format option that returns the image format, the delay between images and the number of scenes. This is the current way of identifying if the image is an animated gif or not. For us the results after this patch where the following:
__Number of pictures:__ 17
__Size:__ 7-8 MB (16 MPixel)
__Number of configs:__ 3 (so 51 resizes in total)
__Time without the patch:__ 5 minutes 40 seconds
__Time with the patch:__ 1 minute 16 seconds

Feedback would be appreciated since I'm no im/gm expert, so I don't know if there's a better way to do this (especially without the string splitting magic).

Regards,
Ben