### PR TITLE
Added little paragraph to link to extender plugin as a fitting partner

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ The following sites and libraries are using Grunt Responsive Images (because the
 
 And the inspiration for [grunt-responsive-videos](https://github.com/sjwilliams/grunt-responsive-videos).
 
+Also, the plugin [grunt-responsive-images-extender](https://github.com/smaxtastic/grunt-responsive-images-extender) is a fitting add-on to leverage your images in `srcset` and `sizes` attributes of your `img` tags.
+
 Please let us know if your live site or library uses Grunt Responsive Images. We'll add our favorites.
 
 ## FAQ


### PR DESCRIPTION
Sorry for the blunt PR, but I love your plugin and it inspired me to do the next step ([grunt-responsive-images-extender](https://github.com/smaxtastic/grunt-responsive-images-extender)). I thought this might be useful for users of your plugin as well.