### PR TITLE
Corrects 'sample' function overriding 'crop' function

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -353,7 +353,7 @@ module.exports = function(grunt) {
 
         if (!sizeOptions.aspectRatio && sizeOptions.width && sizeOptions.height) {
           // crop image
-          sizingMethod = '^';
+          sizingMethod = '!'; // Aspect ratio is false, force specified size.
           mode = 'crop';
         }
 
@@ -394,7 +394,9 @@ module.exports = function(grunt) {
           image
             .sample(sizeTo.width, sizeTo.height, sizingMethod)
             .quality(sizeOptions.quality);
-        } else {
+        } else if (mode != 'crop') {
+          // 'sample' is a simplified form of 'resize'.
+          // 'resize' is what we do by default, but not if crop is already specified.
           image
             .resize(sizeTo.width, sizeTo.height, sizingMethod)
             .quality(sizeOptions.quality);


### PR DESCRIPTION
When the code finds that user did not call for 'sample' function, the code correctly assumes the task must do a 'resize'.

Unfortunately, the default behavior ('resize') should have been specified higher up in the code, rather than as an if-else in the check for user-call to 'sample' function.