### PR TITLE
Fixing size handling

### DIFF
--- a/tasks/responsive_images.js
+++ b/tasks/responsive_images.js
@@ -366,8 +366,12 @@ module.exports = function(grunt) {
               sizingMethod = '!';
             }
           } else if (sizeOptions.aspectRatio) {
-            sizeTo.width = size.width;
-            sizeTo.height = size.height;
+            if (sizeOptions.width > size.width) {
+              sizeTo.width = size.width;
+            }
+            if (sizeOptions.height > size.height) {
+              sizeTo.height = size.height;
+            }
           }
 
           if (sizeOptions.createNoScaledImage) {


### PR DESCRIPTION
When images have different orientations (portrait / landscape) usualy the resizing to eg. 1200x1200 the long side should fit into this values and the short side should be resized according to fit aspectRatio.

Actually the task ignores images, when one side of the original image is smaller, than the according sizeTo-value.
e.g. the original image is 1500x500 and it should fit into 1200x1200 actually the task generates an image with 1500x500 instead of 1200x400.

This Bug is fixed with this changes.